### PR TITLE
Fix a typo which caused a problem with 4 byte long utf-8 chars.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [21,22,23]
+        otp_version: [22,23,24]
         os: [ubuntu-latest]
 
     container:

--- a/test/diffy_tests.erl
+++ b/test/diffy_tests.erl
@@ -91,7 +91,8 @@ prop_inner_diff() ->
                 (SourceText == diffy:source_text(Patches) andalso DestinationText == diffy:destination_text(Patches))
         end).
 
-
+%% Return true iff the parameter which is passed is a valid patch.
+%%
 is_valid_patch([]) ->
     true;
 is_valid_patch([{Op, Bin} | Rest]) when Op =:= insert orelse Op =:= delete orelse Op =:= equal ->
@@ -104,6 +105,8 @@ is_valid_patch([{Op, Bin} | Rest]) when Op =:= insert orelse Op =:= delete orels
 is_valid_patch(_) ->
     false.
 
+%% Return true if the parameter passed is a valid utf-8 binary.
+%%
 is_valid_utf8_binary(<<>>) ->
     true;
 is_valid_utf8_binary(<<_C/utf8, Rest/binary>>) ->

--- a/test/diffy_tests.erl
+++ b/test/diffy_tests.erl
@@ -53,10 +53,9 @@ prop_cleanup_efficiency() ->
 
 html_like() ->
     proper_types:resize(200,
-                        list(frequency([{80, range($a, $z)},       % letters
-                                        {18, oneof(["&amp;", "&gt;", "<script>", "<br />", "<p>", "</p>", "<div>", "</div>"])}, % tags
-                                        {2, utf8(1)},
-                                        {2, utf8(2)},
+                        list(frequency([{70, range($a, $z)},       % letters
+                                        {20, oneof(["&amp;", "&gt;", "<script>", "<br />", "<p>", "</p>", "<div>", "</div>"])}, % tags
+                                        {2, utf8(4)},              % Some small portions of unicode chars.
                                         {2, range($0, $9)},        % numbers
                                         {2, $\s},                  % whitespace
                                         {4,  $\n},                 % linebreaks


### PR DESCRIPTION
During the work on https://github.com/mmzeeman/zotonic_mod_teleview I discovered a problem with patches which where generated. When there was a patch with only a close matching 4 byte long utf-8 encoded character in the tail of a prefix, illegal patches where generated. 

This problem was not picked up by the property based tests, because they did not test for uff-8 validity of the generated patches.

- Fixed the typo
- Enhanced the property based tests so these kind of problems are discovered.