### PR TITLE
Fix typo creating > char after <span> in pretty_html function

### DIFF
--- a/src/diffy.erl
+++ b/src/diffy.erl
@@ -535,7 +535,7 @@ pretty_html([{Op, Data}|T], Acc) ->
         delete ->
             [<<"<del style='background:#ffe6e6;'>">>, Text, <<"</del>">>];
         equal ->
-            [<<"<span>>">>, Text, <<"</span>">>]
+            [<<"<span>">>, Text, <<"</span>">>]
     end,
     pretty_html(T, [HTML|Acc]).
 

--- a/test/diffy_tests.erl
+++ b/test/diffy_tests.erl
@@ -120,10 +120,10 @@ is_valid_utf8_binary(_) ->
 
 pretty_html_test() ->
     ?assertEqual(<<>>, pretty_html([])),
-    ?assertEqual(<<"<span>>test</span>">>, pretty_html([{equal, <<"test">>}])),
-    ?assertEqual(<<"<del style='background:#ffe6e6;'>foo</del><span>>test</span>">>, 
+    ?assertEqual(<<"<span>test</span>">>, pretty_html([{equal, <<"test">>}])),
+    ?assertEqual(<<"<del style='background:#ffe6e6;'>foo</del><span>test</span>">>, 
         pretty_html([{delete, <<"foo">>}, {equal, <<"test">>}])),
-    ?assertEqual(<<"<ins style='background:#e6ffe6;'>foo</ins><span>>test</span>">>, 
+    ?assertEqual(<<"<ins style='background:#e6ffe6;'>foo</ins><span>test</span>">>, 
         pretty_html([{insert, <<"foo">>}, {equal, <<"test">>}])),
     ok.
 


### PR DESCRIPTION
Please ignore if this is intentional but when using `pretty_html` an extra `">"` char is created resulting e.g. in the below.

```html
<span>>Something</span>
```